### PR TITLE
Lazy loading is added

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -485,3 +485,11 @@ body {
   color: #1d0f44ad;
   transition: all 0.3s ease;
 }
+
+.lazy {
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.loaded {
+  opacity: 1;
+}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
 
 <head>
+  <div class="lazy" data-src="index.html"></div>
+
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -73,7 +77,6 @@
       </div>
     </div>
   </section>
-
   <div class="title1">Projects</div>
 
   <section class="hero-section">

--- a/script.js
+++ b/script.js
@@ -203,3 +203,48 @@ function typeLetter() {
 }
 
 const intervalId = setInterval(typeLetter, 100);
+
+(function() {
+	'use strict';
+  
+	var lazyElements = [].slice.call(document.querySelectorAll('.lazy'));
+  
+	var loadLazyContent = function(lazyElement) {
+	  var url = lazyElement.getAttribute('data-src');
+  
+	  // Make an AJAX request to fetch the lazy content
+	  var xhr = new XMLHttpRequest();
+	  xhr.onreadystatechange = function() {
+		if (xhr.readyState === XMLHttpRequest.DONE) {
+		  if (xhr.status === 200) {
+			// Set the fetched content as the innerHTML of the lazy element
+			lazyElement.innerHTML = xhr.responseText;
+			lazyElement.classList.add('loaded');
+		  }
+		}
+	  };
+	  xhr.open('GET', url, true);
+	  xhr.send();
+	};
+  
+	var lazyLoadHandler = function() {
+	  lazyElements.forEach(function(lazyElement) {
+		var rect = lazyElement.getBoundingClientRect();
+  
+		// Check if the lazy element is within the viewport
+		if (rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)) {
+		  loadLazyContent(lazyElement);
+		}
+	  });
+  
+	  // Remove the event listener once all lazy elements are loaded
+	  if (lazyElements.length === 0) {
+		window.removeEventListener('scroll', lazyLoadHandler);
+	  }
+	};
+  
+	// Add the lazyLoadHandler to the scroll event
+	window.addEventListener('scroll', lazyLoadHandler);
+	lazyLoadHandler(); // Call it once to load any initially visible elements
+  })();
+  


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #435 

In this code, I  added the class "lazy" to the elements  to lazy load and specified the URL of the lazy content using the data-src attribute. The script will make an AJAX request to fetch the content from the provided URL and set it as the innerHTML of the lazy element.

Additionally, the code adds a scroll event listener to trigger the lazy loading when the elements come into the viewport. The lazy elements that are already visible on page load will be loaded immediately, while the remaining elements will be loaded as the user scrolls.



<!-- Add screenshots to preview the changes  -->

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.